### PR TITLE
Point users to the new RISC-V github organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, install homebrew:
 
 Get this tap:
 
-    $ brew tap ucb-bar/riscv
+    $ brew tap riscv/riscv
 
 Build the toolchain:
 


### PR DESCRIPTION
We've moved over to http://github.com/riscv/ as the place to store
RISC-V software ports.