### PR TITLE
Work around build error on M1

### DIFF
--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -29,6 +29,11 @@ class RiscvGnuToolchain < Formula
     ]
     args << "--enable-multilib" if build.with?("multilib")
 
+    # Workaround for M1
+    # See https://github.com/riscv/homebrew-riscv/issues/47
+    system 'sed', '-i', '.bak', 's/.*=host-darwin.o$//', 'riscv-gcc/gcc/config.host'
+    system 'sed', '-i', '.bak', 's/.* x-darwin.$//', 'riscv-gcc/gcc/config.host'
+
     system "./configure", *args
     system "make"
 


### PR DESCRIPTION
Resolves #47.

Note the implications of this patch aren't fully understood.
However, `brew test riscv-tools` passes.