### PR TITLE
multilib: use cmodel=medany when multilib is enabled

### DIFF
--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -27,6 +27,8 @@ class RiscvGnuToolchain < Formula
       "--prefix=#{prefix}",
     ]
     args << "--enable-multilib" if build.with?("multilib")
+    # avoid certain types of relocation errors when multilib is enabled
+    args << "--with-cmodel=medany" if build.with?("multilib")
 
     # Workaround for M1
     # See https://github.com/riscv/homebrew-riscv/issues/47


### PR DESCRIPTION
This change mitigates a number of linker errors due to unsupported
relocation types when multilib is enabled.

A typical error would be of the form:

```
relocation truncated to fit: R_RISCV_HI20 against `.LC0'
```

There are a number of similar issues filed, but that
example comes from riscv/riscv-gnu-toolchain#784.

In particular, this change allowed me to build the Zephyr
RTOS for riscv on macos with `CONFIG_NEWLIB_LIBC=y` without any
such linker errors.

Fixes #57