### PR TITLE
Default to -mcmodel=medany

### DIFF
--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -25,6 +25,7 @@ class RiscvGnuToolchain < Formula
 
     args = [
       "--prefix=#{prefix}",
+      "--with-cmodel=medany",
     ]
     args << "--enable-multilib" if build.with?("multilib")
 


### PR DESCRIPTION
This does the right thing for more people's memory maps.

It will result in a very slight perf regression in programs heavy in global variable access.  For application code, the old behavior can be obtained by explicitly passing -mcmodel=medlow.

Supersedes #58

Note, I haven't tested this!!