### PR TITLE
Build the 32 bit tools by default (aka --enable-multilib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,4 @@ To pull in the latest version of a package, you can force an install and compile
 Supporting 32 bit Targets
 -------------------------
 
-By default the toolchain only supports 64 bit RISC-V targets. To install a toolchain that supports both 64 bit and 32 bit:
-
-    $ brew install riscv-gnu-toolchain --with-multilib
+By default the toolchain supports 64 bit and 32 bit RISC-V targets.

--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -10,8 +10,6 @@ class RiscvGnuToolchain < Formula
     sha256 big_sur: "9215a88e36c8f69d8503ca568cb73fc9df8cbe50a982671d1b7a25f4cb0b496e"
   end
 
-  option "with-multilib", "Build with multilib support"
-
   depends_on "gawk" => :build
   depends_on "gnu-sed" => :build
   depends_on "gmp"
@@ -26,8 +24,8 @@ class RiscvGnuToolchain < Formula
     args = [
       "--prefix=#{prefix}",
       "--with-cmodel=medany",
+      "--enable-multilib",
     ]
-    args << "--enable-multilib" if build.with?("multilib")
 
     # Workaround for M1
     # See https://github.com/riscv/homebrew-riscv/issues/47


### PR DESCRIPTION
I'm not sure if there is a downside to shipping the full RISC-V GCC by default, but it would certainly make it easier to do embedded development on 32 bit targets. Right now it takes over 30 minutes to compile everything from source.

And with the growing number of RISC-V embedded hardware platforms, I assume this will be in greater demand going forward:
- https://www.sparkfun.com/products/18036
- https://www.sparkfun.com/products/15594
- https://www.sifive.com/boards/hifive1-rev-b
- https://docs.opentitan.org/doc/ug/getting_started/