### PR TITLE
Use big sur bottle for catalina

### DIFF
--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -20,6 +20,7 @@ class RiscvGnuToolchain < Formula
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "zstd"
 
   def install
     # disable crazy flag additions


### PR DESCRIPTION
I'm apparently not on the latest version of MacOS, and so when trying `brew install riscv-gnu-toolchain` it started building from source. I hacked the formula file a little and hosted the existing bottle locally with "catalina" in its name and managed to get brew to install it. It seems to work!

However, on the first compilation I got:

```
$ make RISCV=1
  CC        ../../libtock/crt0.c
dyld: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: /usr/local/Cellar/riscv-gnu-toolchain/master/libexec/gcc/riscv64-unknown-elf/11.1.0/cc1
  Reason: image not found
riscv64-unknown-elf-gcc: internal compiler error: Abort trap: 6 signal terminated program cc1
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://gcc.gnu.org/bugs/> for instructions.
make: *** [../../libtock/build/rv32i/crt0.o] Error 4
```

I solved that with:

```
$ brew install zstd
```

So, perhaps zstd is an expected dependency. I added it to the dependency list (but I'm not sure if there is some difference between catalina and big sur somehow).

The last part of this PR that I cannot do is the existing bottle would need to be copied on the server to the filename `riscv-gnu-toolchain-master.catalina.bottle.6.tar.gz`.