### PR TITLE
workaround for enabling rvv

### DIFF
--- a/riscv-tools.rb
+++ b/riscv-tools.rb
@@ -5,8 +5,10 @@ class RiscvTools < Formula
   version "0.2"
   sha256 "cb919eb7cf11071c6d11c721a9e77893a2dbe9158466e444eb3dd8476a89b7b4"
 
+  option "with-enable-rvv", "Workaround to enable RISCV Vector Extension"
+  
   # install rest of tools
-  depends_on "riscv-gnu-toolchain"
+  depends_on "riscv-gnu-toolchain" => [:build, "--with-enable-rvv"]
   depends_on "riscv-isa-sim"
   depends_on "riscv-pk"
 


### PR DESCRIPTION
RVV has been supported since gcc-13. An option is added here to enable RISC-V vector extensions building, since gcc is not bumped to gcc-13 yet in toolchain

see 
* https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1239 
* https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1301